### PR TITLE
BUGFIX Stats - Number of counters to 4 bytes

### DIFF
--- a/bmp.py
+++ b/bmp.py
@@ -190,9 +190,9 @@ class BMPStats(Packet):
     name = "BMPStats"
     fields_desc = [
         PacketField("PerPeer", None, PerPeerHeader),
-        FieldLenField("len", None, count_of="counters"),
+        FieldLenField("len", None, fmt="I", count_of="counters"),
         PacketListField(
-            "counters", None, BMPStatsCounter, count_from=lambda pkt: pkt.len
+            "counters", None, BMPStatsCounter, count_from=lambda pkt: pkt.length
         ),
     ]
 


### PR DESCRIPTION
Number of counters was 2B, now fixed to 4B as per RFC:

> Following the common BMP header and per-peer header is a 4-byte field that indicates the number of counters in the stats message where each counter is encoded as a TLV.