### PR TITLE
Copy license header from bgp.py to bmp.py

### DIFF
--- a/bmp.py
+++ b/bmp.py
@@ -1,3 +1,17 @@
+# This is based on a file that is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
 """
 Simple implementation of BMP on Scapy.
 BMP is defined in RFC 7854.


### PR DESCRIPTION
This copies the license header/boilerplate from `bgp.py` to `bmp.py`.

Without some kind of license header, it could be "guessed" that the `LICENSE` file applies (GPLv2) — but it's unclear if it is `GPLv2 only` or `GPLv2 or later` since that's specified in the header.  I'm guessing the intent was to keep with the scapy terms, which is `GPLv2 or later`.

(It's not possible to use a different license anyway since the code is derivative of scapy, but clarity is important in these matters…)